### PR TITLE
Added better error reporting for FollowJointTrajectoryControllers

### DIFF
--- a/moveit_simple_controller_manager/include/moveit_simple_controller_manager/follow_joint_trajectory_controller_handle.h
+++ b/moveit_simple_controller_manager/include/moveit_simple_controller_manager/follow_joint_trajectory_controller_handle.h
@@ -91,6 +91,26 @@ protected:
   void controllerDoneCallback(const actionlib::SimpleClientGoalState& state,
                               const control_msgs::FollowJointTrajectoryResultConstPtr& result)
   {
+    // Output custom error message for FollowJointTrajectoryResult if necessary
+    switch( result->error_code )
+    {
+      case control_msgs::FollowJointTrajectoryResult::INVALID_GOAL:
+        ROS_WARN_STREAM("Controller " << name_ << " failed with error code INVALID_GOAL");
+        break;
+      case control_msgs::FollowJointTrajectoryResult::INVALID_JOINTS:
+        ROS_WARN_STREAM("Controller " << name_ << " failed with error code INVALID_JOINTS");
+        break;
+      case control_msgs::FollowJointTrajectoryResult::OLD_HEADER_TIMESTAMP:
+        ROS_WARN_STREAM("Controller " << name_ << " failed with error code OLD_HEADER_TIMESTAMP");
+        break;
+      case control_msgs::FollowJointTrajectoryResult::PATH_TOLERANCE_VIOLATED:
+        ROS_WARN_STREAM("Controller " << name_ << " failed with error code PATH_TOLERANCE_VIOLATED");
+        break;
+      case control_msgs::FollowJointTrajectoryResult::GOAL_TOLERANCE_VIOLATED:
+        ROS_WARN_STREAM("Controller " << name_ << " failed with error code GOAL_TOLERANCE_VIOLATED");
+        break;
+    }
+
     finishControllerExecution(state);
   }
 


### PR DESCRIPTION
Currently it does not use the `FollowJointTrajectoryResultConstPtr` result info, which is problematic for the ros_control JointTrajectoryController because no where can you gleam why your controller is failing.
