### PR TITLE
Allow simple controller manager to ignore virtual joints without failing

### DIFF
--- a/moveit_simple_controller_manager/include/moveit_simple_controller_manager/follow_joint_trajectory_controller_handle.h
+++ b/moveit_simple_controller_manager/include/moveit_simple_controller_manager/follow_joint_trajectory_controller_handle.h
@@ -66,8 +66,7 @@ public:
 
     if (!trajectory.multi_dof_joint_trajectory.points.empty())
     {
-      ROS_ERROR("FollowJointTrajectoryController: cannot execute multi-dof trajectories.");
-      return false;
+      ROS_WARN("FollowJointTrajectoryController: cannot execute multi-dof trajectories.");
     }
 
     if (done_)


### PR DESCRIPTION
The MoveIt Simple Controller Manager currently fails when a FollowJointJointTrajectoryController receives a request that includes a virtual joint. However, there are cases such as a biped robot where a virtual joint is included in a planning group that sends requests to the controller. While it is ok for the trajectory controller to ignore the virtual joint, it should not fail. This PR instead makes it just issue a warning.

@mmurooka
