### PR TITLE
More informative warning message about multi-dof trajectories.

### DIFF
--- a/moveit_simple_controller_manager/include/moveit_simple_controller_manager/follow_joint_trajectory_controller_handle.h
+++ b/moveit_simple_controller_manager/include/moveit_simple_controller_manager/follow_joint_trajectory_controller_handle.h
@@ -66,7 +66,7 @@ public:
 
     if (!trajectory.multi_dof_joint_trajectory.points.empty())
     {
-      ROS_WARN("FollowJointTrajectoryController: cannot execute multi-dof trajectories.");
+      ROS_WARN("FollowJointTrajectoryController: %s cannot execute multi-dof trajectories.", name_.c_str());
     }
 
     if (done_)


### PR DESCRIPTION
A tiny change I've had lying around for a while.  I wanted to know which controller was being sent the wrong trajectories.
