### PR TITLE
Logging cleanup

### DIFF
--- a/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
+++ b/moveit_simple_controller_manager/src/moveit_simple_controller_manager.cpp
@@ -55,7 +55,7 @@ public:
   {
     if (!node_handle_.hasParam("controller_list"))
     {
-      ROS_ERROR_STREAM("MoveitSimpleControllerManager: No controller_list specified.");
+      ROS_ERROR_STREAM("No controller_list specified.");
       return;
     }
 
@@ -63,7 +63,7 @@ public:
     node_handle_.getParam("controller_list", controller_list);
     if (controller_list.getType() != XmlRpc::XmlRpcValue::TypeArray)
     {
-      ROS_ERROR("MoveitSimpleControllerManager: controller_list should be specified as an array");
+      ROS_ERROR("Parameter controller_list should be specified as an array");
       return;
     }
 
@@ -72,7 +72,7 @@ public:
     {
       if (!controller_list[i].hasMember("name") || !controller_list[i].hasMember("joints"))
       {
-        ROS_ERROR("MoveitSimpleControllerManager: Name and joints must be specifed for each controller");
+        ROS_ERROR("Name and joints must be specifed for each controller");
         continue;
       }
 
@@ -85,22 +85,22 @@ public:
         {
           /* TODO: this used to be called "ns", renaming to "action_ns" and will remove in the future */
           action_ns = std::string(controller_list[i]["ns"]);
-          ROS_WARN("MoveitSimpleControllerManager: use of 'ns' is deprecated, use 'action_ns' instead.");
+          ROS_WARN("Use of 'ns' is deprecated, use 'action_ns' instead.");
         }
         else if (controller_list[i].hasMember("action_ns"))
           action_ns = std::string(controller_list[i]["action_ns"]);
         else
-          ROS_WARN("MoveitSimpleControllerManager: please note that 'action_ns' no longer has a default value.");
+          ROS_WARN("Please note that 'action_ns' no longer has a default value.");
 
         if (controller_list[i]["joints"].getType() != XmlRpc::XmlRpcValue::TypeArray)
         {
-          ROS_ERROR_STREAM("MoveitSimpleControllerManager: The list of joints for controller " << name << " is not specified as an array");
+          ROS_ERROR_STREAM("The list of joints for controller " << name << " is not specified as an array");
           continue;
         }
 
         if (!controller_list[i].hasMember("type"))
         {
-          ROS_ERROR_STREAM("MoveitSimpleControllerManager: No type specified for controller " << name);
+          ROS_ERROR_STREAM("No type specified for controller " << name);
           continue;
         }
 
@@ -132,7 +132,7 @@ public:
             if (controller_list[i].hasMember("allow_failure"))
                 static_cast<GripperControllerHandle*>(new_handle.get())->allowFailure(true);
 
-            ROS_INFO_STREAM("MoveitSimpleControllerManager: Added GripperCommand controller for " << name );
+            ROS_INFO_STREAM("Added GripperCommand controller for " << name );
             controllers_[name] = new_handle;
           }
         }
@@ -141,7 +141,7 @@ public:
           new_handle.reset(new FollowJointTrajectoryControllerHandle(name, action_ns));
           if (static_cast<FollowJointTrajectoryControllerHandle*>(new_handle.get())->isConnected())
           {
-            ROS_INFO_STREAM("MoveitSimpleControllerManager: Added FollowJointTrajectory controller for " << name );
+            ROS_INFO_STREAM("Added FollowJointTrajectory controller for " << name );
             controllers_[name] = new_handle;
           }
         }
@@ -162,7 +162,7 @@ public:
       }
       catch (...)
       {
-        ROS_ERROR("MoveitSimpleControllerManager: Unable to parse controller information");
+        ROS_ERROR("Unable to parse controller information");
       }
     }
   }


### PR DESCRIPTION
Instead of 

> ROS_ERROR_STREAM("MoveitSimpleControllerManager:...

it should be 

> ROS_ERROR_STREAM_NAMED("MoveitSimpleControllerManager", "...

However since the simple_controller_manager package only has one file, it does not need to be namespaces because the logging functionality will already show the package name. This cleans up the loggging.
