### PR TITLE
Support for ros_control

### DIFF
--- a/moveit_plugins/package.xml
+++ b/moveit_plugins/package.xml
@@ -14,6 +14,7 @@
 
   <run_depend>moveit_simple_controller_manager</run_depend>
   <run_depend>moveit_fake_controller_manager</run_depend>
+  <run_depend>moveit_ros_control_interface</run_depend>
 
   <export>
     <metapackage/>

--- a/moveit_ros_control_interface/CMakeLists.txt
+++ b/moveit_ros_control_interface/CMakeLists.txt
@@ -1,0 +1,87 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(moveit_ros_control_interface)
+
+find_package(catkin REQUIRED COMPONENTS
+  actionlib
+  controller_manager_msgs
+  moveit_core
+  moveit_simple_controller_manager
+  pluginlib
+  trajectory_msgs
+)
+## System dependencies are found with CMake's conventions
+find_package(Boost REQUIRED COMPONENTS system thread)
+
+
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES
+  CATKIN_DEPENDS moveit_core 
+  DEPENDS Boost
+)
+
+include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+
+add_library(${PROJECT_NAME}_plugin
+  src/controller_manager_plugin.cpp
+)
+target_link_libraries(${PROJECT_NAME}_plugin
+  ${catkin_LIBRARIES} ${Boost_LIBRARIES}
+)
+
+add_library(${PROJECT_NAME}_trajectory_plugin
+  src/joint_trajectory_controller_plugin.cpp
+)
+target_link_libraries(${PROJECT_NAME}_trajectory_plugin
+  ${catkin_LIBRARIES} ${Boost_LIBRARIES}
+)
+
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+install(TARGETS ${PROJECT_NAME}_plugin ${PROJECT_NAME}_trajectory_plugin
+ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Mark cpp header files for installation
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+install(FILES moveit_core_plugins.xml moveit_ros_control_interface_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_canopen_master.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/moveit_ros_control_interface/README.md
+++ b/moveit_ros_control_interface/README.md
@@ -1,7 +1,7 @@
 # Overview
 
 This package provides plugins of base class `moveit_controller_manager::MoveItControllerManager` and a new plugin base class for `moveit_controller_manager::MoveItControllerHandle` allocators.
-The allocator class is necessary because `moveit_controller_manager::MoveItControllerHandle` needa a name passed to the constructor.
+The allocator class is necessary because `moveit_controller_manager::MoveItControllerHandle` needs a name passed to the constructor.
 Two variantes are provided, `moveit_ros_control_interface::MoveItControllerManager` for interfacing a singe ros_control node and `moveit_ros_control_interface::MoveItMultiControllerManager` for seamless integration with any number of ros_control nodes.
 
 
@@ -23,8 +23,23 @@ In your MoveIt! launch file (e.g. `ROBOT_moveit_config/launch/ROBOT_moveit_contr
 ```
 
 And make sure so set the `ros_control_namespace` parameter to the namespace (without the /contoller_manager/ part) of the ros_control-based node you like to interface.
-If you are using the `moveit_setup_assistent` you can add it to `ROBOT_moveit_config/config/ROBOT_controllers.yaml`.
-
+If you are using the `moveit_setup_assistent` you can add it to `ROBOT_moveit_config/config/ROBOT_controllers.yaml`, e.g.:
+```
+ros_control_namespace: /ROBOT
+controller_list:
+  - name: /ROBOT/position_trajectory_controller
+    action_ns: follow_joint_trajectory
+    type: FollowJointTrajectory
+    default: true
+    joints:
+      - joint_a1
+      - joint_a2
+      - joint_a3
+      - joint_a4
+      - joint_a5
+      - joint_a6
+      - joint_a7
+```
 
 ### Controller switching
 MoveIt! can decide which controllers have to be started and stopped.

--- a/moveit_ros_control_interface/README.md
+++ b/moveit_ros_control_interface/README.md
@@ -1,0 +1,28 @@
+# Overview
+
+This package provides plugins of base class `moveit_controller_manager::MoveItControllerManager` and a new plugin base class for `moveit_controller_manager::MoveItControllerHandle` allocators.
+The allocator class is necessary because `moveit_controller_manager::MoveItControllerHandle` need a name passed to constructor.
+
+# moveit_ros_control_interface::MoveItControllerManager
+This plugin intefaces a single ros_control-driven node in the namespace given in the `~ros_control_namespace` ROS parameter.
+It polls all controller via the `list_controllers` and passes their properties to MoveIt!.
+The polling is throttled to 1 Hertz.
+
+## Handle plugins
+The actual handle creation is delegated to allocator plugin of base class `moveit_ros_control_interface::ControllerHandleAllocator`.
+These plugins should be registered with lookup names that match the corresponding controller types.
+
+Currently plugins for `position_controllers/JointTrajectoryController`, `velocity_controllers/JointTrajectoryController` and `effort_controllers/JointTrajectoryController` are available, which simple wrap `moveit_simple_controller_manager::FollowJointTrajectoryControllerHandle` instances.
+
+## Controller switching
+Moveit! can decide which controllers have to be started and stopped.
+Since only controller names with registered allocator plugins in are handed over to MoveIt!, this implementation takes care of stopping other controllers based on their claimed resources and the resources for the to-be-started controlles.
+
+## Namespaces
+All controller names get prefixed by the namespace of the ros_control node.
+For this to work the controller names should not contain slashes. This is a strict requirement if the ros_control  namespace is `/`.
+
+# moveit_ros_control_interface::MoveItMultiControllerManager
+
+This plugin does not need further configuration. It polls the ROS master for services and identifies ros_control nodes automatically.
+It spawns `moveit_ros_control_interface::MoveItControllerManager` instances with their namespace and takes cares of proper delegation.

--- a/moveit_ros_control_interface/README.md
+++ b/moveit_ros_control_interface/README.md
@@ -1,22 +1,22 @@
 # Overview
 
 This package provides plugins of base class `moveit_controller_manager::MoveItControllerManager` and a new plugin base class for `moveit_controller_manager::MoveItControllerHandle` allocators.
-The allocator class is necessary because `moveit_controller_manager::MoveItControllerHandle` need a name passed to constructor.
+The allocator class is necessary because `moveit_controller_manager::MoveItControllerHandle` needa a name passed to the constructor.
 
 # moveit_ros_control_interface::MoveItControllerManager
 This plugin intefaces a single ros_control-driven node in the namespace given in the `~ros_control_namespace` ROS parameter.
-It polls all controller via the `list_controllers` and passes their properties to MoveIt!.
+It polls all controllers via the `list_controllers` service and passes their properties to MoveIt!.
 The polling is throttled to 1 Hertz.
 
 ## Handle plugins
-The actual handle creation is delegated to allocator plugin of base class `moveit_ros_control_interface::ControllerHandleAllocator`.
+The actual handle creation is delegated to allocator plugins of base class `moveit_ros_control_interface::ControllerHandleAllocator`.
 These plugins should be registered with lookup names that match the corresponding controller types.
 
-Currently plugins for `position_controllers/JointTrajectoryController`, `velocity_controllers/JointTrajectoryController` and `effort_controllers/JointTrajectoryController` are available, which simple wrap `moveit_simple_controller_manager::FollowJointTrajectoryControllerHandle` instances.
+Currently plugins for `position_controllers/JointTrajectoryController`, `velocity_controllers/JointTrajectoryController` and `effort_controllers/JointTrajectoryController` are available, which simply wrap `moveit_simple_controller_manager::FollowJointTrajectoryControllerHandle` instances.
 
 ## Controller switching
-Moveit! can decide which controllers have to be started and stopped.
-Since only controller names with registered allocator plugins in are handed over to MoveIt!, this implementation takes care of stopping other controllers based on their claimed resources and the resources for the to-be-started controlles.
+MoveIt! can decide which controllers have to be started and stopped.
+Since only controller names with registered allocator plugins are handed over to MoveIt!, this implementation takes care of stopping other confflicting controllers based on their claimed resources and the resources for the to-be-started controlles.
 
 ## Namespaces
 All controller names get prefixed by the namespace of the ros_control node.

--- a/moveit_ros_control_interface/README.md
+++ b/moveit_ros_control_interface/README.md
@@ -2,27 +2,46 @@
 
 This package provides plugins of base class `moveit_controller_manager::MoveItControllerManager` and a new plugin base class for `moveit_controller_manager::MoveItControllerHandle` allocators.
 The allocator class is necessary because `moveit_controller_manager::MoveItControllerHandle` needa a name passed to the constructor.
+Two variantes are provided, `moveit_ros_control_interface::MoveItControllerManager` for interfacing a singe ros_control node and `moveit_ros_control_interface::MoveItMultiControllerManager` for seamless integration with any number of ros_control nodes.
 
-# moveit_ros_control_interface::MoveItControllerManager
+
+## moveit_ros_control_interface::MoveItControllerManager
 This plugin intefaces a single ros_control-driven node in the namespace given in the `~ros_control_namespace` ROS parameter.
 It polls all controllers via the `list_controllers` service and passes their properties to MoveIt!.
 The polling is throttled to 1 Hertz.
 
-## Handle plugins
+### Handle plugins
 The actual handle creation is delegated to allocator plugins of base class `moveit_ros_control_interface::ControllerHandleAllocator`.
 These plugins should be registered with lookup names that match the corresponding controller types.
 
 Currently plugins for `position_controllers/JointTrajectoryController`, `velocity_controllers/JointTrajectoryController` and `effort_controllers/JointTrajectoryController` are available, which simply wrap `moveit_simple_controller_manager::FollowJointTrajectoryControllerHandle` instances.
 
-## Controller switching
+### Setup
+In your MoveIt! launch file (e.g. `ROBOT_moveit_config/launch/ROBOT_moveit_controller_manager.launch.xml`) set the `moveit_controller_manager` parameter:
+```
+<arg name="moveit_controller_manager" default="moveit_ros_control_interface::MoveItControllerManager" />
+```
+
+And make sure so set the `ros_control_namespace` parameter to the namespace (without the /contoller_manager/ part) of the ros_control-based node you like to interface.
+If you are using the `moveit_setup_assistent` you can add it to `ROBOT_moveit_config/config/ROBOT_controllers.yaml`.
+
+
+### Controller switching
 MoveIt! can decide which controllers have to be started and stopped.
 Since only controller names with registered allocator plugins are handed over to MoveIt!, this implementation takes care of stopping other confflicting controllers based on their claimed resources and the resources for the to-be-started controlles.
 
-## Namespaces
+### Namespaces
 All controller names get prefixed by the namespace of the ros_control node.
 For this to work the controller names should not contain slashes. This is a strict requirement if the ros_control  namespace is `/`.
 
-# moveit_ros_control_interface::MoveItMultiControllerManager
+## moveit_ros_control_interface::MoveItMultiControllerManager
 
 This plugin does not need further configuration. It polls the ROS master for services and identifies ros_control nodes automatically.
 It spawns `moveit_ros_control_interface::MoveItControllerManager` instances with their namespace and takes cares of proper delegation.
+
+
+### Setup
+Just set the `moveit_controller_manager` parameter in your MoveIt! launch file (e.g. `ROBOT_moveit_config/launch/ROBOT_moveit_controller_manager.launch.xml`)
+```
+<arg name="moveit_controller_manager" default="moveit_ros_control_interface::MoveItMultiControllerManager" />
+```

--- a/moveit_ros_control_interface/include/moveit_ros_control_interface/ControllerHandle.h
+++ b/moveit_ros_control_interface/include/moveit_ros_control_interface/ControllerHandle.h
@@ -1,0 +1,56 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, Fraunhofer IPA
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Fraunhofer IPA nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Mathias Lüdtke */
+
+
+#ifndef MOVEIT_ROS_CONTROL_INTERFACE_CONTROLLER_HANDLE_H
+#define MOVEIT_ROS_CONTROL_INTERFACE_CONTROLLER_HANDLE_H
+
+#include <moveit/controller_manager/controller_manager.h>
+
+namespace moveit_ros_control_interface {
+
+/**
+ * Base class for MoveItControllerHandle allocators
+ */
+class ControllerHandleAllocator{
+public:
+    virtual moveit_controller_manager::MoveItControllerHandlePtr alloc(const std::string &name, const std::vector<std::string> &resources) = 0;
+    virtual ~ControllerHandleAllocator() {}
+};
+
+} // namespace moveit_ros_control_interface
+
+#endif // MOVEIT_ROS_CONTROL_INTERFACE_CONTROLLER_HANDLE_H

--- a/moveit_ros_control_interface/include/moveit_ros_control_interface/ControllerHandle.h
+++ b/moveit_ros_control_interface/include/moveit_ros_control_interface/ControllerHandle.h
@@ -34,23 +34,24 @@
 
 /* Author: Mathias Lüdtke */
 
-
 #ifndef MOVEIT_ROS_CONTROL_INTERFACE_CONTROLLER_HANDLE_H
 #define MOVEIT_ROS_CONTROL_INTERFACE_CONTROLLER_HANDLE_H
 
 #include <moveit/controller_manager/controller_manager.h>
 
-namespace moveit_ros_control_interface {
-
+namespace moveit_ros_control_interface
+{
 /**
  * Base class for MoveItControllerHandle allocators
  */
-class ControllerHandleAllocator{
+class ControllerHandleAllocator
+{
 public:
-    virtual moveit_controller_manager::MoveItControllerHandlePtr alloc(const std::string &name, const std::vector<std::string> &resources) = 0;
-    virtual ~ControllerHandleAllocator() {}
+  virtual moveit_controller_manager::MoveItControllerHandlePtr alloc(const std::string &name,
+                                                                     const std::vector<std::string> &resources) = 0;
+  virtual ~ControllerHandleAllocator() {}
 };
 
-} // namespace moveit_ros_control_interface
+}  // namespace moveit_ros_control_interface
 
-#endif // MOVEIT_ROS_CONTROL_INTERFACE_CONTROLLER_HANDLE_H
+#endif  // MOVEIT_ROS_CONTROL_INTERFACE_CONTROLLER_HANDLE_H

--- a/moveit_ros_control_interface/moveit_core_plugins.xml
+++ b/moveit_ros_control_interface/moveit_core_plugins.xml
@@ -1,0 +1,10 @@
+<class_libraries>
+  <library path="lib/libmoveit_ros_control_interface_plugin">
+    <class type="moveit_ros_control_interface::MoveItControllerManager" base_class_type="moveit_controller_manager::MoveItControllerManager">
+        <description>ros_control controller manager interface for MoveIt!</description>
+    </class>
+    <class type="moveit_ros_control_interface::MoveItMultiControllerManager" base_class_type="moveit_controller_manager::MoveItControllerManager">
+        <description>multiple ros_control controller managers interface for MoveIt!</description>
+    </class>
+  </library>
+</class_libraries>

--- a/moveit_ros_control_interface/moveit_ros_control_interface_plugins.xml
+++ b/moveit_ros_control_interface/moveit_ros_control_interface_plugins.xml
@@ -1,0 +1,13 @@
+<class_libraries>
+  <library path="lib/libmoveit_ros_control_interface_trajectory_plugin">
+    <class name="position_controllers/JointTrajectoryController" type="moveit_ros_control_interface::JointTrajectoryControllerAllocator" base_class_type="moveit_ros_control_interface::ControllerHandleAllocator">
+        <description></description>
+    </class>
+    <class name="velocity_controllers/JointTrajectoryController" type="moveit_ros_control_interface::JointTrajectoryControllerAllocator" base_class_type="moveit_ros_control_interface::ControllerHandleAllocator">
+        <description></description>
+    </class>
+    <class name="effort_controllers/JointTrajectoryController" type="moveit_ros_control_interface::JointTrajectoryControllerAllocator" base_class_type="moveit_ros_control_interface::ControllerHandleAllocator">
+        <description></description>
+    </class>
+  </library>
+</class_libraries>

--- a/moveit_ros_control_interface/package.xml
+++ b/moveit_ros_control_interface/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>moveit_ros_control_interface</name>
-  <version>0.0.0</version>
+  <version>0.5.6</version>
   <description>ros_control controller manager interface for MoveIt!</description>
 
   <maintainer email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</maintainer>

--- a/moveit_ros_control_interface/package.xml
+++ b/moveit_ros_control_interface/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>moveit_ros_control_interface</name>
+  <version>0.0.0</version>
+  <description>ros_control controller manager interface for MoveIt!</description>
+
+  <maintainer email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</maintainer>
+  <author email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</author>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>actionlib</depend>
+  <depend>controller_manager_msgs</depend>
+  <depend>moveit_core</depend>
+  <depend>moveit_simple_controller_manager</depend>
+  <depend>pluginlib</depend>
+  <depend>trajectory_msgs</depend>
+
+  <export>
+     <moveit_core plugin="${prefix}/moveit_core_plugins.xml" />
+     <moveit_ros_control_interface plugin="${prefix}/moveit_ros_control_interface_plugins.xml" />
+  </export>
+</package>

--- a/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -119,7 +119,7 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
 public:
 
     /**
-     * The default constructor reads he namespace read from ~ros_control_namespace param and defaults to /
+     * The default constructor reads the namespace from ~ros_control_namespace param and defaults to /
      */
     MoveItControllerManager()
     : ns_(ros::NodeHandle("~").param("ros_control_namespace", std::string("/"))), loader_("moveit_ros_control_interface", "moveit_ros_control_interface::ControllerHandleAllocator") {

--- a/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -141,9 +141,16 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
             if(handle) handles_.insert(std::make_pair(name, handle));
         }
     }
+
+    /**
+     * get fully qualified name
+     * @param name name to be resolved to an absolute name
+     * @return resolved name
+     */
     std::string getAbsName(const std::string &name){
         return ros::names::append(ns_, name);
     }
+    
 public:
 
     /**

--- a/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -83,7 +83,7 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
   typedef std::map<std::string, controller_manager_msgs::ControllerState> ControllersMap;
   ControllersMap managed_controllers_;
   ControllersMap active_controllers_;
-  typedef std::map<std::string, boost::shared_ptr<ControllerHandleAllocator>> AllocatorsMap;
+  typedef std::map<std::string, boost::shared_ptr<ControllerHandleAllocator> > AllocatorsMap;
   AllocatorsMap allocators_;
 
   typedef std::map<std::string, moveit_controller_manager::MoveItControllerHandlePtr> HandleMap;

--- a/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -163,6 +163,7 @@ public:
      * @return
      */
     virtual moveit_controller_manager::MoveItControllerHandlePtr getControllerHandle(const std::string &name){
+        boost::mutex::scoped_lock lock(controllers_mutex_);
         HandleMap::iterator it = handles_.find(name);
         if(it != handles_.end()){ // controller is is manager by this interface
             return it->second;

--- a/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -1,0 +1,423 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, Fraunhofer IPA
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Fraunhofer IPA nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Mathias Lüdtke */
+
+
+#include <ros/ros.h>
+
+#include <moveit_ros_control_interface/ControllerHandle.h>
+
+#include <moveit/controller_manager/controller_manager.h>
+
+#include <controller_manager_msgs/ListControllers.h>
+#include <controller_manager_msgs/SwitchController.h>
+
+#include <pluginlib/class_list_macros.h>
+#include <map>
+
+#include <pluginlib/class_loader.h>
+
+#include <boost/bimap.hpp>
+
+namespace moveit_ros_control_interface {
+
+/**
+ *
+ * @param t timestamp to check, is update if timeout duration was passed
+ * @param[in] timeout timeout duration in seconds
+ * @param[in] force force timeout
+ * @return True if timeout duration was passed
+ */
+bool checkTimeout(ros::Time &t, double timeout, bool force = false){
+    ros::Time now = ros::Time::now();
+    if(force || (now-t) >=ros::Duration(timeout)){
+        t = now;
+        return true;
+    }
+    return false;
+}
+
+/**
+ * moveit_controller_manager::MoveItControllerManager sub class that interfaces one ros_control controller_manager instance.
+ * All service call and names are relative to ns_.
+ */
+class MoveItControllerManager : public moveit_controller_manager::MoveItControllerManager {
+    const std::string ns_;
+    pluginlib::ClassLoader< ControllerHandleAllocator > loader_;
+    typedef std::map<std::string, controller_manager_msgs::ControllerState> ControllersMap;
+    ControllersMap managed_controllers_;
+    ControllersMap active_controllers_;
+    typedef std::map<std::string, boost::shared_ptr<ControllerHandleAllocator> > AllocatorsMap;
+    AllocatorsMap allocators_;
+    ros::Time controllers_stamp_;
+    boost::mutex controllers_mutex_;
+
+    /**
+     * Check if given controller is active
+     * @param s state of controller
+     * @return true if controller is active
+     */
+    static bool isActive(const controller_manager_msgs::ControllerState &s) { return s.state == std::string("running"); }
+
+    /**
+     * Call list_controllers and populate managed_controllers_ and active_controllers_.
+     * Throttled down to 1 Hz
+     * controllers_mutex_ must be locked externally
+     * @param force force rediscover
+     */
+    void discover(bool force=false){
+        if(!checkTimeout(controllers_stamp_, 1.0, force)) return;
+
+        controller_manager_msgs::ListControllers srv;
+        if(!ros::service::call(ns_ + "controller_manager/list_controllers", srv)){
+            ROS_WARN_STREAM("Failed to read controllers from " << ns_ <<  "controller_manager/list_controllers");
+        }
+        managed_controllers_.clear();
+        active_controllers_.clear();
+        for(size_t i=0; i < srv.response.controller.size(); ++i){
+            const controller_manager_msgs::ControllerState & c = srv.response.controller[i];
+            if(isActive(c)){
+                active_controllers_.insert(std::make_pair(c.name, c)); // without namespace
+            }
+            if(loader_.isClassAvailable(c.type)){
+                managed_controllers_.insert(std::make_pair(ns_ + c.name, c)); // with namespace
+            }
+        }
+    }
+public:
+
+    /**
+     * The default constructor reads he namespace read from ~ros_control_namespace param and defaults to /
+     */
+    MoveItControllerManager()
+    : ns_(ros::NodeHandle("~").param("ros_control_namespace", std::string("/"))), loader_("moveit_ros_control_interface", "moveit_ros_control_interface::ControllerHandleAllocator") {
+        ROS_INFO_STREAM("Started moveit_ros_control_interface::MoveItControllerManager for namespace " << ns_);
+    }
+
+    /**
+     * Configure interface with namespace
+     * @param ns namespace of ros_control node (without /controller_manager/)
+     */
+    MoveItControllerManager(const std::string& ns) : ns_(ns), loader_("moveit_ros_control_interface", "moveit_ros_control_interface::ControllerHandleAllocator") {
+    }
+
+    /**
+     * Allocate MoveItControllerHandle according to type of given controller.
+     * Might create allocator object first.
+     * @param name
+     * @return
+     */
+    virtual moveit_controller_manager::MoveItControllerHandlePtr getControllerHandle(const std::string &name){
+        ControllersMap::iterator it = managed_controllers_.find(name);
+        if(it != managed_controllers_.end()){ // controller is is manager by this interface
+            const std::string &type = it->second.type;
+            AllocatorsMap::iterator alloc_it = allocators_.find(type);
+            if(alloc_it == allocators_.end()){ // create allocator is needed
+                alloc_it = allocators_.insert(std::make_pair(type, loader_.createInstance(type))).first;
+            }
+            return alloc_it->second->alloc(name, it->second.resources); // allocate handler
+        }
+        return moveit_controller_manager::MoveItControllerHandlePtr();
+    }
+
+    /**
+     * Refresh controller list and output all managed controllers
+     * @param[out] names list of controllers (with namespace)
+     */
+    virtual void getControllersList(std::vector<std::string> &names){
+        boost::mutex::scoped_lock lock(controllers_mutex_);
+        discover();
+
+        for(ControllersMap::iterator it = managed_controllers_.begin(); it != managed_controllers_.end(); ++it){
+            names.push_back(it->first);
+        }
+    }
+
+    /**
+     * Refresh controller list and output all active, managed controllers
+     * @param[out] names list of controllers (with namespace)
+     */
+    virtual void getActiveControllers(std::vector<std::string> &names){
+        boost::mutex::scoped_lock lock(controllers_mutex_);
+        discover();
+
+        for(ControllersMap::iterator it = managed_controllers_.begin(); it != managed_controllers_.end(); ++it){
+            if(isActive(it->second)) names.push_back(it->first);
+        }
+    }
+
+    /**
+     * Read resources from cached controller states
+     * @param[in] name name of controller (with namespace)
+     * @param[out] joints
+     */
+    virtual void getControllerJoints(const std::string &name, std::vector<std::string> &joints){
+        boost::mutex::scoped_lock lock(controllers_mutex_);
+        ControllersMap::iterator it = managed_controllers_.find(name);
+        if(it != managed_controllers_.end()){
+            joints = it->second.resources;
+        }
+    }
+
+    /**
+     * Refresh controller state and output the state of the given one, only active_ will be set
+     * @param[in] name name of controller (with namespace)
+     * @return state
+     */
+    virtual ControllerState getControllerState(const std::string &name){
+        boost::mutex::scoped_lock lock(controllers_mutex_);
+        discover();
+
+        ControllerState c;
+        ControllersMap::iterator it = managed_controllers_.find(name);
+        if(it != managed_controllers_.end()){
+            c.active_ = isActive(it->second);
+        }
+        return c;
+    }
+
+    /**
+     * Filter lists for managed controller and computes switching set.
+     * Stopped list might be extended by unsupported controllers that claim needed resources
+     * @param activate
+     * @param deactivate
+     * @return true if switching succeeded
+     */
+    virtual bool switchControllers(const std::vector<std::string> &activate, const std::vector<std::string> &deactivate){
+        boost::mutex::scoped_lock lock(controllers_mutex_);
+        discover(true);
+
+        typedef boost::bimap< std::string, std::string> resources_bimap;
+
+        resources_bimap claimed_resources;
+
+        // fill bimap with active controllers and their resources
+        for(ControllersMap::iterator c = active_controllers_.begin(); c != active_controllers_.end(); ++c){
+            for(std::vector<std::string>::iterator r = c->second.resources.begin(); r != c->second.resources.end(); ++r){
+                claimed_resources.insert(resources_bimap::value_type(c->second.name, *r));
+            }
+        }
+
+        controller_manager_msgs::SwitchController srv;
+
+        for(std::vector<std::string>::const_iterator it = deactivate.begin(); it != deactivate.end(); ++it){
+            ControllersMap::iterator c = managed_controllers_.find(*it);
+            if(c != managed_controllers_.end()){ // controller belongs to this manager
+                srv.request.stop_controllers.push_back(c->second.name);
+                claimed_resources.right.erase(c->second.name); // remove resources
+            }
+        }
+
+
+        for(std::vector<std::string>::const_iterator it = activate.begin(); it != activate.end(); ++it){
+            ControllersMap::iterator c = managed_controllers_.find(*it);
+            if(c != managed_controllers_.end()){ // controller belongs to this manager
+                srv.request.start_controllers.push_back(c->second.name);
+
+                for(std::vector<std::string>::iterator r = c->second.resources.begin(); r != c->second.resources.end(); ++r){ // for all claimed resource
+                    resources_bimap::right_const_iterator res = claimed_resources.right.find(*r);
+                    if(res != claimed_resources.right.end()){ // resource is claimed
+                        srv.request.stop_controllers.push_back(res->second); // add claiming controller to stop list
+                        claimed_resources.left.erase(res->second);  // remove claimed resources
+                    }
+                }
+            }
+        }
+        srv.request.strictness = srv.request.STRICT;
+
+        if (!srv.request.start_controllers.empty() || srv.request.stop_controllers.empty()){ // something to switch?
+            if(!ros::service::call(ns_ + "controller_manager/switch_controller", srv)){
+                ROS_ERROR_STREAM("Could switch controllers at " << ns_);
+            }
+            discover(true);
+            return srv.response.ok;
+        }
+        return true;
+    }
+    typedef boost::shared_ptr<MoveItControllerManager> Ptr;
+};
+/**
+ * MoveItMultiControllerManager discovers all running ros_control node and delegates member function to the corresponding MoveItControllerManager instances
+ */
+class  MoveItMultiControllerManager : public moveit_controller_manager::MoveItControllerManager {
+    typedef std::map<std::string, moveit_ros_control_interface::MoveItControllerManager::Ptr > ControllerManagersMap;
+    ControllerManagersMap controller_managers_;
+    ros::Time controller_managers_stamp_;
+    boost::mutex controller_managers_mutex_;
+
+    /**
+     * Poll ROS master for services and filters all controller_manager/list_controllers instances
+     * Throttled down to 1 Hz
+     * controller_managers_mutex_ must be locked externally
+     */
+    void discover(){
+        if(!checkTimeout(controller_managers_stamp_, 1.0)) return;
+
+        XmlRpc::XmlRpcValue args, result, system_state;
+        args[0] = ros::this_node::getName();
+
+        if (!ros::master::execute("getSystemState", args, result, system_state, true))
+        {
+            return;
+        }
+
+        // refer to http://wiki.ros.org/ROS/Master_API#Name_service_and_system_state
+        XmlRpc::XmlRpcValue services = system_state[2];
+
+
+        for (int i = 0; i < services.size(); ++i)
+        {
+            std::string service = services[i][0];
+            std::size_t found = service.find("controller_manager/list_controllers");
+            if(found != std::string::npos){
+                std::string ns = service.substr(0,found);
+                if(controller_managers_.find(ns) == controller_managers_.end()){ // create MoveItControllerManager if it does not exists
+                    ROS_INFO_STREAM("Adding controller_manager interface for node at namespace " << ns);
+                    controller_managers_.insert(std::make_pair(ns, boost::make_shared<moveit_ros_control_interface::MoveItControllerManager>(ns)));
+                }
+            }
+        }
+    }
+
+    /**
+     * Get namespace (including leading and trailing slashes) from controller name
+     * @param name
+     * @return extracted namespace or / is none is found
+     */
+    static std::string getNamespace(const std::string& name){
+        size_t pos = name.find('/',1);
+        if(pos == std::string::npos) pos = 0;
+        return name.substr(0, pos+1);
+    }
+
+public:
+
+    /**
+     * Find appropriate interface and delegate handle creation
+     * @param name
+     * @return handle
+     */
+    virtual moveit_controller_manager::MoveItControllerHandlePtr getControllerHandle(const std::string &name){
+        boost::mutex::scoped_lock lock(controller_managers_mutex_);
+
+        std::string ns = getNamespace(name);
+        ControllerManagersMap::iterator it = controller_managers_.find(ns);
+        if(it != controller_managers_.end()){
+            return it->second->getControllerHandle(name);
+        }
+        return moveit_controller_manager::MoveItControllerHandlePtr();
+    }
+
+    /**
+     * Read all managed controllers from discovered interfaces
+     * @param names
+     */
+    virtual void getControllersList(std::vector<std::string> &names){
+        boost::mutex::scoped_lock lock(controller_managers_mutex_);
+        discover();
+
+        for(ControllerManagersMap::iterator it = controller_managers_.begin(); it != controller_managers_.end(); ++it){
+            it->second->getControllersList(names);
+        }
+    }
+
+    /**
+     * Read all active, managed controllers from discovered interfaces
+     * @param names
+     */
+    virtual void getActiveControllers(std::vector<std::string> &names){
+        boost::mutex::scoped_lock lock(controller_managers_mutex_);
+        discover();
+
+        for(ControllerManagersMap::iterator it = controller_managers_.begin(); it != controller_managers_.end(); ++it){
+            it->second->getActiveControllers(names);
+        }
+    }
+
+    /**
+     * Find appropriate interface and delegate joints query
+     * @param name
+     * @param joints
+     */
+    virtual void getControllerJoints(const std::string &name, std::vector<std::string> &joints){
+        boost::mutex::scoped_lock lock(controller_managers_mutex_);
+
+        std::string ns = getNamespace(name);
+        ControllerManagersMap::iterator it = controller_managers_.find(ns);
+        if(it != controller_managers_.end()){
+            it->second->getControllerJoints(name, joints);
+        }
+    }
+
+    /**
+     * Find appropriate interface and delegate state query
+     * @param name
+     * @return
+     */
+    virtual ControllerState getControllerState(const std::string &name){
+        boost::mutex::scoped_lock lock(controller_managers_mutex_);
+
+        std::string ns = getNamespace(name);
+        ControllerManagersMap::iterator it = controller_managers_.find(ns);
+        if(it != controller_managers_.end()){
+            return it->second->getControllerState(name);
+        }
+        return ControllerState();
+    }
+
+    /**
+     * delegates switch  to all known interfaces. Stops of first failing switch.
+     * @param activate
+     * @param deactivate
+     * @return
+     */
+    virtual bool switchControllers(const std::vector<std::string> &activate, const std::vector<std::string> &deactivate){
+        boost::mutex::scoped_lock lock(controller_managers_mutex_);
+
+        for(ControllerManagersMap::iterator it = controller_managers_.begin(); it != controller_managers_.end(); ++it){
+            if(!it->second->switchControllers(activate, deactivate)) return false;
+        }
+        return true;
+    }
+
+};
+
+} // namespace moveit_ros_control_interface
+
+PLUGINLIB_EXPORT_CLASS(moveit_ros_control_interface::MoveItControllerManager,
+                       moveit_controller_manager::MoveItControllerManager);
+
+PLUGINLIB_EXPORT_CLASS(moveit_ros_control_interface::MoveItMultiControllerManager,
+                       moveit_controller_manager::MoveItControllerManager);

--- a/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -53,7 +53,7 @@
 namespace moveit_ros_control_interface
 {
 /**
- *
+ * \brief check for timeout
  * @param t timestamp to check, is update if timeout duration was passed
  * @param[in] timeout timeout duration in seconds
  * @param[in] force force timeout
@@ -71,9 +71,10 @@ bool checkTimeout(ros::Time &t, double timeout, bool force = false)
 }
 
 /**
- * moveit_controller_manager::MoveItControllerManager sub class that interfaces one ros_control controller_manager
+ * \brief moveit_controller_manager::MoveItControllerManager sub class that interfaces one ros_control
+ * controller_manager
  * instance.
- * All service call and names are relative to ns_.
+ * All services and names are relative to ns_.
  */
 class MoveItControllerManager : public moveit_controller_manager::MoveItControllerManager
 {
@@ -92,16 +93,16 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
   boost::mutex controllers_mutex_;
 
   /**
-   * Check if given controller is active
+   * \brief Check if given controller is active
    * @param s state of controller
    * @return true if controller is active
    */
   static bool isActive(const controller_manager_msgs::ControllerState &s) { return s.state == std::string("running"); }
 
   /**
-   * Call list_controllers and populate managed_controllers_ and active_controllers_. Allocates handles if needed.
-   * Throttled down to 1 Hz
-   * controllers_mutex_ must be locked externally
+   * \brief  Call list_controllers and populate managed_controllers_ and active_controllers_. Allocates handles if
+   * needed.
+   * Throttled down to 1 Hz, controllers_mutex_ must be locked externally
    * @param force force rediscover
    */
   void discover(bool force = false)
@@ -133,7 +134,7 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
   }
 
   /**
-   * Allocates a MoveItControllerHandle instance for the given controller
+   * \brief Allocates a MoveItControllerHandle instance for the given controller
    * Might create allocator object first.
    * @param name fully qualified name of the controller
    * @param controller controller information
@@ -156,7 +157,7 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
   }
 
   /**
-   * get fully qualified name
+   * \brief get fully qualified name
    * @param name name to be resolved to an absolute name
    * @return resolved name
    */
@@ -164,7 +165,7 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
 
 public:
   /**
-   * The default constructor reads the namespace from ~ros_control_namespace param and defaults to /
+   * \brief The default constructor. Reads the namespace from ~ros_control_namespace param and defaults to /
    */
   MoveItControllerManager()
     : ns_(ros::NodeHandle("~").param("ros_control_namespace", std::string("/")))
@@ -174,7 +175,7 @@ public:
   }
 
   /**
-   * Configure interface with namespace
+   * \brief Configure interface with namespace
    * @param ns namespace of ros_control node (without /controller_manager/)
    */
   MoveItControllerManager(const std::string &ns)
@@ -183,7 +184,7 @@ public:
   }
 
   /**
-   * Find and return the pre-allocated handle for the given controller.
+   * \brief Find and return the pre-allocated handle for the given controller.
    * @param name
    * @return
    */
@@ -199,7 +200,7 @@ public:
   }
 
   /**
-   * Refresh controller list and output all managed controllers
+   * \brief Refresh controller list and output all managed controllers
    * @param[out] names list of controllers (with namespace)
    */
   virtual void getControllersList(std::vector<std::string> &names)
@@ -214,7 +215,7 @@ public:
   }
 
   /**
-   * Refresh controller list and output all active, managed controllers
+   * \brief Refresh controller list and output all active, managed controllers
    * @param[out] names list of controllers (with namespace)
    */
   virtual void getActiveControllers(std::vector<std::string> &names)
@@ -230,7 +231,7 @@ public:
   }
 
   /**
-   * Read resources from cached controller states
+   * \brief Read resources from cached controller states
    * @param[in] name name of controller (with namespace)
    * @param[out] joints
    */
@@ -245,7 +246,7 @@ public:
   }
 
   /**
-   * Refresh controller state and output the state of the given one, only active_ will be set
+   * \brief Refresh controller state and output the state of the given one, only active_ will be set
    * @param[in] name name of controller (with namespace)
    * @return state
    */
@@ -264,7 +265,7 @@ public:
   }
 
   /**
-   * Filter lists for managed controller and computes switching set.
+   * \brief Filter lists for managed controller and computes switching set.
    * Stopped list might be extended by unsupported controllers that claim needed resources
    * @param activate
    * @param deactivate
@@ -334,7 +335,7 @@ public:
   typedef boost::shared_ptr<MoveItControllerManager> Ptr;
 };
 /**
- * MoveItMultiControllerManager discovers all running ros_control node and delegates member function to the
+ *  \brief MoveItMultiControllerManager discovers all running ros_control node and delegates member function to the
  * corresponding MoveItControllerManager instances
  */
 class MoveItMultiControllerManager : public moveit_controller_manager::MoveItControllerManager
@@ -345,9 +346,8 @@ class MoveItMultiControllerManager : public moveit_controller_manager::MoveItCon
   boost::mutex controller_managers_mutex_;
 
   /**
-   * Poll ROS master for services and filters all controller_manager/list_controllers instances
-   * Throttled down to 1 Hz
-   * controller_managers_mutex_ must be locked externally
+   * \brief  Poll ROS master for services and filters all controller_manager/list_controllers instances
+   * Throttled down to 1 Hz, controller_managers_mutex_ must be locked externally
    */
   void discover()
   {
@@ -383,7 +383,7 @@ class MoveItMultiControllerManager : public moveit_controller_manager::MoveItCon
   }
 
   /**
-   * Get namespace (including leading and trailing slashes) from controller name
+   * \brief Get namespace (including leading and trailing slashes) from controller name
    * @param name
    * @return extracted namespace or / is none is found
    */
@@ -397,7 +397,7 @@ class MoveItMultiControllerManager : public moveit_controller_manager::MoveItCon
 
 public:
   /**
-   * Find appropriate interface and delegate handle creation
+   * \brief Find appropriate interface and delegate handle creation
    * @param name
    * @return handle
    */
@@ -415,7 +415,7 @@ public:
   }
 
   /**
-   * Read all managed controllers from discovered interfaces
+   * \brief Read all managed controllers from discovered interfaces
    * @param names
    */
   virtual void getControllersList(std::vector<std::string> &names)
@@ -430,7 +430,7 @@ public:
   }
 
   /**
-   * Read all active, managed controllers from discovered interfaces
+   * \brief Read all active, managed controllers from discovered interfaces
    * @param names
    */
   virtual void getActiveControllers(std::vector<std::string> &names)
@@ -445,7 +445,7 @@ public:
   }
 
   /**
-   * Find appropriate interface and delegate joints query
+   * \brief Find appropriate interface and delegate joints query
    * @param name
    * @param joints
    */
@@ -462,7 +462,7 @@ public:
   }
 
   /**
-   * Find appropriate interface and delegate state query
+   * \brief Find appropriate interface and delegate state query
    * @param name
    * @return
    */
@@ -480,7 +480,7 @@ public:
   }
 
   /**
-   * delegates switch  to all known interfaces. Stops of first failing switch.
+   * \brief delegates switch  to all known interfaces. Stops of first failing switch.
    * @param activate
    * @param deactivate
    * @return

--- a/moveit_ros_control_interface/src/joint_trajectory_controller_plugin.cpp
+++ b/moveit_ros_control_interface/src/joint_trajectory_controller_plugin.cpp
@@ -34,27 +34,29 @@
 
 /* Author: Mathias Lüdtke */
 
-
 #include <ros/ros.h>
 #include <moveit_ros_control_interface/ControllerHandle.h>
 #include <pluginlib/class_list_macros.h>
 #include <boost/shared_ptr.hpp>
 #include <moveit_simple_controller_manager/follow_joint_trajectory_controller_handle.h>
 
-namespace moveit_ros_control_interface {
-
+namespace moveit_ros_control_interface
+{
 /**
  * Simple allocator for moveit_simple_controller_manager::FollowJointTrajectoryControllerHandle instances.
  */
-class JointTrajectoryControllerAllocator : public ControllerHandleAllocator {
+class JointTrajectoryControllerAllocator : public ControllerHandleAllocator
+{
 public:
-    virtual moveit_controller_manager::MoveItControllerHandlePtr alloc(const std::string &name, const std::vector<std::string> &resources){
-        return boost::make_shared<moveit_simple_controller_manager::FollowJointTrajectoryControllerHandle>(name, "follow_joint_trajectory");
-    }
-
+  virtual moveit_controller_manager::MoveItControllerHandlePtr alloc(const std::string &name,
+                                                                     const std::vector<std::string> &resources)
+  {
+    return boost::make_shared<moveit_simple_controller_manager::FollowJointTrajectoryControllerHandle>(
+        name, "follow_joint_trajectory");
+  }
 };
 
-} // namespace moveit_ros_control_interface
+}  // namespace moveit_ros_control_interface
 
 PLUGINLIB_EXPORT_CLASS(moveit_ros_control_interface::JointTrajectoryControllerAllocator,
                        moveit_ros_control_interface::ControllerHandleAllocator);

--- a/moveit_ros_control_interface/src/joint_trajectory_controller_plugin.cpp
+++ b/moveit_ros_control_interface/src/joint_trajectory_controller_plugin.cpp
@@ -43,7 +43,7 @@
 namespace moveit_ros_control_interface
 {
 /**
- * Simple allocator for moveit_simple_controller_manager::FollowJointTrajectoryControllerHandle instances.
+ * \brief Simple allocator for moveit_simple_controller_manager::FollowJointTrajectoryControllerHandle instances.
  */
 class JointTrajectoryControllerAllocator : public ControllerHandleAllocator
 {

--- a/moveit_ros_control_interface/src/joint_trajectory_controller_plugin.cpp
+++ b/moveit_ros_control_interface/src/joint_trajectory_controller_plugin.cpp
@@ -1,0 +1,60 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, Fraunhofer IPA
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Fraunhofer IPA nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Mathias Lüdtke */
+
+
+#include <ros/ros.h>
+#include <moveit_ros_control_interface/ControllerHandle.h>
+#include <pluginlib/class_list_macros.h>
+#include <boost/shared_ptr.hpp>
+#include <moveit_simple_controller_manager/follow_joint_trajectory_controller_handle.h>
+
+namespace moveit_ros_control_interface {
+
+/**
+ * Simple allocator for moveit_simple_controller_manager::FollowJointTrajectoryControllerHandle instances.
+ */
+class JointTrajectoryControllerAllocator : public ControllerHandleAllocator {
+public:
+    virtual moveit_controller_manager::MoveItControllerHandlePtr alloc(const std::string &name, const std::vector<std::string> &resources){
+        return boost::make_shared<moveit_simple_controller_manager::FollowJointTrajectoryControllerHandle>(name, "follow_joint_trajectory");
+    }
+
+};
+
+} // namespace moveit_ros_control_interface
+
+PLUGINLIB_EXPORT_CLASS(moveit_ros_control_interface::JointTrajectoryControllerAllocator,
+                       moveit_ros_control_interface::ControllerHandleAllocator);

--- a/moveit_simple_controller_manager/CMakeLists.txt
+++ b/moveit_simple_controller_manager/CMakeLists.txt
@@ -22,9 +22,8 @@ link_directories(${catkin_LIBRARY_DIRS})
 
 catkin_package(
   LIBRARIES
-  INCLUDE_DIRS
-  DEPENDS
-    moveit_core
+  INCLUDE_DIRS include
+  CATKIN_DEPENDS moveit_core actionlib control_msgs
     )
 
 include_directories(include)
@@ -36,4 +35,7 @@ install(TARGETS moveit_simple_controller_manager LIBRARY DESTINATION ${CATKIN_PA
 
 install(FILES moveit_simple_controller_manager_plugin_description.xml
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+       )
+install(DIRECTORY include/${PROJECT_NAME}/
+       DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
        )


### PR DESCRIPTION
These plugins connect to running ros_control nodes and add handles for execution.

For the sake of flexibility I have outsource the handle creation to plugins. I added a simple implementation for the `joint_trajectory_controller` types that uses the `moveit_simple_controller_manager` action handles.
That's why I had to expose its headers.

I have tested it with our https://github.com/ipa320/cob_gazebo_plugins environment.
it still lacks proper unit tests and the configuration is rather limited.

it would be great if other ros_control users would test it with theirs setups and give some feedback.
