### PR TITLE
Fix conversion of shared ptr to bool for C++11.

### DIFF
--- a/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -92,7 +92,7 @@ public:
 
   bool isConnected() const
   {
-    return controller_action_client_;
+    return static_cast<bool>(controller_action_client_);
   }
 
   virtual bool cancelExecution()


### PR DESCRIPTION
C++11 supports explicit conversion operators, and `boost::shared_ptr` adopted them (when available) for `operator bool() const`. The `ActionBasedControllerHandle` relies on an implicit conversion to `bool`. Since GCC 6 now compiles with C++11 support enabled by default, the `simple_controller_manager` package no longer compiles with that version onwards.

The fix is very simple: add an explicit cast.
