### PR TITLE
install plugin xml even if it's no functional controller

### DIFF
--- a/moveit_controller_manager_example/CMakeLists.txt
+++ b/moveit_controller_manager_example/CMakeLists.txt
@@ -30,11 +30,8 @@ include_directories(include)
 add_library(moveit_controller_manager_example src/moveit_controller_manager_example.cpp)
 target_link_libraries(moveit_controller_manager_example ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
-# This is not a working controller, so we do not install it. However, the lines below
-# should be enabled for functional controllers
+install(TARGETS moveit_controller_manager_example LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
-#install(TARGETS moveit_controller_manager_example LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
-
-#install(FILES moveit_controller_manager_example_plugin_description.xml
-#        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-#       )
+install(FILES moveit_controller_manager_example_plugin_description.xml
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+       )


### PR DESCRIPTION
If an xml-file is referenced in the package.xml, it _has_ to exist. Otherwise
each invocation of the plugin-module will produce errors such as this one:

> [ERROR] [1466021391.880651302]: Skipping XML Document
> "~/ros/indigo/moveit/install/share/moveit_controller_manager_example/moveit_controller_manager_example_plugin_description.xml"
> which had no Root Element.  This likely means the XML is malformed or missing.
