### PR TITLE
Enable C++11 support.

### DIFF
--- a/moveit_controller_manager_example/CMakeLists.txt
+++ b/moveit_controller_manager_example/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(moveit_controller_manager_example)
 
+add_compile_options(-std=c++11)
+
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()

--- a/moveit_fake_controller_manager/CMakeLists.txt
+++ b/moveit_fake_controller_manager/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(moveit_fake_controller_manager)
 
+add_compile_options(-std=c++11)
+
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()

--- a/moveit_ros_control_interface/CMakeLists.txt
+++ b/moveit_ros_control_interface/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(moveit_ros_control_interface)
 
+add_compile_options(-std=c++11)
+
 find_package(catkin REQUIRED COMPONENTS
   actionlib
   controller_manager_msgs

--- a/moveit_simple_controller_manager/CMakeLists.txt
+++ b/moveit_simple_controller_manager/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(moveit_simple_controller_manager)
 
+add_compile_options(-std=c++11)
+
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()


### PR DESCRIPTION
Enables C++11 support for `moveit_plugins` packages. This is required for the FCL 0.5 PRs.
